### PR TITLE
Changes js files to make them compatible with earlier nodejs versions

### DIFF
--- a/src/geniushub-client.js
+++ b/src/geniushub-client.js
@@ -4,9 +4,8 @@ const axios = require('axios').default;
 
 module.exports = class GeniusHubClient {
 
-    _wholeHouseZoneId = 0;
-
     constructor(token) {
+        this._wholeHouseZoneId = 0;
         this.client =  axios.create({
             baseURL: "https://my.geniushub.co.uk/v1",
             timeout: 10000,

--- a/src/nodes/whole-house.js
+++ b/src/nodes/whole-house.js
@@ -3,18 +3,18 @@
 module.exports = function(RED) {
  
     class  WholeHouseNode {
-        
-        _offableTypes = ["radiator"];
-
-        _commands = {
-            GETZONES: Symbol("GETZONES"),
-            GETSUMMARY: Symbol("GETSUMMARY"),
-            GETTEMPERATURE: Symbol("GETTEMPERATURE"),
-            OFF: Symbol("OFF"),
-            RESTORE: Symbol("RESTORE")
-        };
     
         constructor(config) {
+            this._offableTypes = ["radiator"];
+
+            this._commands = {
+                GETZONES: Symbol("GETZONES"),
+                GETSUMMARY: Symbol("GETSUMMARY"),
+                GETTEMPERATURE: Symbol("GETTEMPERATURE"),
+                OFF: Symbol("OFF"),
+                RESTORE: Symbol("RESTORE")
+            };
+            
             RED.nodes.createNode(this, config);
             this.service = RED.nodes.getNode(config.service);
             

--- a/src/nodes/zone.js
+++ b/src/nodes/zone.js
@@ -4,22 +4,22 @@ module.exports = function(RED) {
 
     class ZoneNode {
         
-        _commands = {
-            GETSTATE: Symbol("GETSTATE"),
-            GETSETPOINT: Symbol("GETSETPOINT"),
-            GETTEMPERATURE: Symbol("GETTEMPERATURE"),
-            GETOVERRIDE: Symbol("GETOVERRIDE"),
-            GETMODE: Symbol("GETMODE"),
-            GETOCCUPIED: Symbol("GETOCCUPIED"),
-            GETTIMERSCHEDULE: Symbol("GETTIMERSCHEDULE"),
-            GETFOOTPRINTSCHEDULE: Symbol("GETFOOTPRINTSCHEDULE"),
-            OFF: Symbol("OFF"),
-            TIMER: Symbol("TIMER"),
-            FOOTPRINT: Symbol("FOOTPRINT"),
-            OVERRIDE: Symbol("OVERRIDE")
-        };
-
         constructor(config) {
+            this._commands = {
+                GETSTATE: Symbol("GETSTATE"),
+                GETSETPOINT: Symbol("GETSETPOINT"),
+                GETTEMPERATURE: Symbol("GETTEMPERATURE"),
+                GETOVERRIDE: Symbol("GETOVERRIDE"),
+                GETMODE: Symbol("GETMODE"),
+                GETOCCUPIED: Symbol("GETOCCUPIED"),
+                GETTIMERSCHEDULE: Symbol("GETTIMERSCHEDULE"),
+                GETFOOTPRINTSCHEDULE: Symbol("GETFOOTPRINTSCHEDULE"),
+                OFF: Symbol("OFF"),
+                TIMER: Symbol("TIMER"),
+                FOOTPRINT: Symbol("FOOTPRINT"),
+                OVERRIDE: Symbol("OVERRIDE")
+            };
+
             RED.nodes.createNode(this,config);
             this.service = RED.nodes.getNode(config.service);
  


### PR DESCRIPTION
This proposed change moves the class variable definitions inside the constructor to make the code compatible with earlier versions of Node (such as Node v10). This is to support systems which cannot be upgraded to Node v12 such as the AlphaWerk UCM/Pi.

This change should be compatible with Node v12.